### PR TITLE
chore: pnpm を 10.33.2 にアップデート

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "packageManager": "pnpm@9.1.2",
+  "packageManager": "pnpm@10.33.2",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",


### PR DESCRIPTION
## Summary
- `package.json` の `packageManager` を `pnpm@9.1.2` から `pnpm@10.33.2` にアップデート
- ローカル環境の pnpm バージョン（10.x）と整合させ、Corepack 経由でチーム内バージョンを統一

## Test plan
- [ ] `pnpm install` がローカルで成功する
- [ ] CI (`Test` ワークフロー) で `pnpm/action-setup@v6` が `packageManager` フィールドから 10.33.2 を解決し、lint / test が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)